### PR TITLE
Add derivative pricing model stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# Investec_Derivatives
+# Investec Derivatives Pricing Models
+
+This repository contains a collection of derivative pricing model stubs used by Investec.
+The implementation focuses on creating a consistent interface for a variety of models.
+The pricing logic still needs to be implemented for each model.
+
+## Supported Models
+
+| Model Name (Front Arena)                       | Scope     | Instruments / Notes                                                  |
+| ---------------------------------------------- | --------- | ------------------------------------------------------------------- |
+| Constant Debt to Equity instrument (CODEQ)     | In        | Confirm if there are live trades available                           |
+| Credit basket linear                           | In        |                                                                     |
+| Zero Coupon                                    | In        | Only need to test Cross currency swaps with long dated tenors        |
+| Price Curve                                    | In        | Commodity                                                            |
+| Commodity Asian Option                         | In        |                                                                     |
+| Hazard Rate Model                              | In        | FX future/forward, Equity future/forward                             |
+| Synthetic Underlying Forward                   | In        |                                                                     |
+| Theoretical dividend futures                   | In        |                                                                     |
+| Underlying Spot                                | In        |                                                                     |
+| Black-Scholes                                  | Out       |                                                                     |
+| Asian Arithmetic Fix MM                        | In        | Equity and FX Options                                                |
+| Theoretical simple dividend option             | In        | Equity dividend option                                               |
+| Total Return Swap                              | In        | Equity TRS                                                           |
+| QEDI Variable Strike Warrant                   | In        |                                                                     |
+| Convexity Adjusted Interest Rate Futures       | In        | FX barrier option, Equity barrier option                             |
+| Barrier Continuous Analytic                    | In        |                                                                     |
+| Discretised Barrier                            | In        |                                                                     |
+| Index-Linked Bond Forward                      | In        |                                                                     |
+| Fund Instrument                                | In        |                                                                     |
+| Bond Futures                                   | Out       |                                                                     |
+| Corporate Bond Model                           | In        |                                                                     |
+| Theoretical dividend-neutral futures           | In        | Equity future/forward                                                |
+| UDMC Cliquet Model                             | In        |                                                                     |
+| Fully Funded TRS (Compound Model)              | In        |                                                                     |
+| UseUnderlyingPrice                             | Out       |                                                                     |
+| Finite Difference                              | In        | American Options on equity and FX underlyings incl. Barrier Options |
+| Variable Strike Warrant Valuation              | Out       |                                                                     |
+| Simple Tradeable Deposit                       | In        | ETF                                                                  |
+
+Each model lives under `derivatives/models/` and exposes a `price()` method. The current
+implementation simply raises `NotImplementedError` as a placeholder for the actual
+pricing logic.

--- a/derivatives/__init__.py
+++ b/derivatives/__init__.py
@@ -1,0 +1,3 @@
+"""Derivative pricing models package."""
+
+from .models import *  # noqa: F401,F403

--- a/derivatives/models/__init__.py
+++ b/derivatives/models/__init__.py
@@ -1,0 +1,30 @@
+"""Collection of derivative pricing models."""
+
+from .base import DerivativeModel
+
+# flake8: noqa
+
+from .constant_debt_to_equity import ConstantDebtToEquity
+from .credit_basket_linear import CreditBasketLinear
+from .zero_coupon import ZeroCoupon
+from .price_curve import PriceCurve
+from .commodity_asian_option import CommodityAsianOption
+from .hazard_rate_model import HazardRateModel
+from .synthetic_underlying_forward import SyntheticUnderlyingForward
+from .theoretical_dividend_futures import TheoreticalDividendFutures
+from .underlying_spot import UnderlyingSpot
+from .asian_arithmetic_fix_mm import AsianArithmeticFixMM
+from .theoretical_simple_dividend_option import TheoreticalSimpleDividendOption
+from .total_return_swap import TotalReturnSwap
+from .qedi_variable_strike_warrant import QEDIVariableStrikeWarrant
+from .convexity_adjusted_interest_rate_futures import ConvexityAdjustedInterestRateFutures
+from .barrier_continuous_analytic import BarrierContinuousAnalytic
+from .discretised_barrier import DiscretisedBarrier
+from .index_linked_bond_forward import IndexLinkedBondForward
+from .fund_instrument import FundInstrument
+from .corporate_bond_model import CorporateBondModel
+from .theoretical_dividend_neutral_futures import TheoreticalDividendNeutralFutures
+from .udmc_cliquet_model import UDMCCliquetModel
+from .fully_funded_trs import FullyFundedTRS
+from .finite_difference import FiniteDifference
+from .simple_tradeable_deposit import SimpleTradeableDeposit

--- a/derivatives/models/asian_arithmetic_fix_mm.py
+++ b/derivatives/models/asian_arithmetic_fix_mm.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class AsianArithmeticFixMM(DerivativeModel):
+    """Placeholder for the AsianArithmeticFixMM pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using AsianArithmeticFixMM model."""
+        raise NotImplementedError("AsianArithmeticFixMM pricing not implemented")

--- a/derivatives/models/barrier_continuous_analytic.py
+++ b/derivatives/models/barrier_continuous_analytic.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class BarrierContinuousAnalytic(DerivativeModel):
+    """Placeholder for the BarrierContinuousAnalytic pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using BarrierContinuousAnalytic model."""
+        raise NotImplementedError("BarrierContinuousAnalytic pricing not implemented")

--- a/derivatives/models/base.py
+++ b/derivatives/models/base.py
@@ -1,0 +1,6 @@
+class DerivativeModel:
+    """Base class for derivative pricing models."""
+
+    def price(self, *args, **kwargs):
+        """Placeholder method for pricing logic."""
+        raise NotImplementedError("Pricing logic not implemented")

--- a/derivatives/models/commodity_asian_option.py
+++ b/derivatives/models/commodity_asian_option.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class CommodityAsianOption(DerivativeModel):
+    """Placeholder for the CommodityAsianOption pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using CommodityAsianOption model."""
+        raise NotImplementedError("CommodityAsianOption pricing not implemented")

--- a/derivatives/models/constant_debt_to_equity.py
+++ b/derivatives/models/constant_debt_to_equity.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class ConstantDebtToEquity(DerivativeModel):
+    """Placeholder for the ConstantDebtToEquity pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using ConstantDebtToEquity model."""
+        raise NotImplementedError("ConstantDebtToEquity pricing not implemented")

--- a/derivatives/models/convexity_adjusted_interest_rate_futures.py
+++ b/derivatives/models/convexity_adjusted_interest_rate_futures.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class ConvexityAdjustedInterestRateFutures(DerivativeModel):
+    """Placeholder for the ConvexityAdjustedInterestRateFutures pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using ConvexityAdjustedInterestRateFutures model."""
+        raise NotImplementedError("ConvexityAdjustedInterestRateFutures pricing not implemented")

--- a/derivatives/models/corporate_bond_model.py
+++ b/derivatives/models/corporate_bond_model.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class CorporateBondModel(DerivativeModel):
+    """Placeholder for the CorporateBondModel pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using CorporateBondModel model."""
+        raise NotImplementedError("CorporateBondModel pricing not implemented")

--- a/derivatives/models/credit_basket_linear.py
+++ b/derivatives/models/credit_basket_linear.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class CreditBasketLinear(DerivativeModel):
+    """Placeholder for the CreditBasketLinear pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using CreditBasketLinear model."""
+        raise NotImplementedError("CreditBasketLinear pricing not implemented")

--- a/derivatives/models/discretised_barrier.py
+++ b/derivatives/models/discretised_barrier.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class DiscretisedBarrier(DerivativeModel):
+    """Placeholder for the DiscretisedBarrier pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using DiscretisedBarrier model."""
+        raise NotImplementedError("DiscretisedBarrier pricing not implemented")

--- a/derivatives/models/finite_difference.py
+++ b/derivatives/models/finite_difference.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class FiniteDifference(DerivativeModel):
+    """Placeholder for the FiniteDifference pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using FiniteDifference model."""
+        raise NotImplementedError("FiniteDifference pricing not implemented")

--- a/derivatives/models/fully_funded_trs.py
+++ b/derivatives/models/fully_funded_trs.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class FullyFundedTRS(DerivativeModel):
+    """Placeholder for the FullyFundedTRS pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using FullyFundedTRS model."""
+        raise NotImplementedError("FullyFundedTRS pricing not implemented")

--- a/derivatives/models/fund_instrument.py
+++ b/derivatives/models/fund_instrument.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class FundInstrument(DerivativeModel):
+    """Placeholder for the FundInstrument pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using FundInstrument model."""
+        raise NotImplementedError("FundInstrument pricing not implemented")

--- a/derivatives/models/hazard_rate_model.py
+++ b/derivatives/models/hazard_rate_model.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class HazardRateModel(DerivativeModel):
+    """Placeholder for the HazardRateModel pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using HazardRateModel model."""
+        raise NotImplementedError("HazardRateModel pricing not implemented")

--- a/derivatives/models/index_linked_bond_forward.py
+++ b/derivatives/models/index_linked_bond_forward.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class IndexLinkedBondForward(DerivativeModel):
+    """Placeholder for the IndexLinkedBondForward pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using IndexLinkedBondForward model."""
+        raise NotImplementedError("IndexLinkedBondForward pricing not implemented")

--- a/derivatives/models/price_curve.py
+++ b/derivatives/models/price_curve.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class PriceCurve(DerivativeModel):
+    """Placeholder for the PriceCurve pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using PriceCurve model."""
+        raise NotImplementedError("PriceCurve pricing not implemented")

--- a/derivatives/models/qedi_variable_strike_warrant.py
+++ b/derivatives/models/qedi_variable_strike_warrant.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class QEDIVariableStrikeWarrant(DerivativeModel):
+    """Placeholder for the QEDIVariableStrikeWarrant pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using QEDIVariableStrikeWarrant model."""
+        raise NotImplementedError("QEDIVariableStrikeWarrant pricing not implemented")

--- a/derivatives/models/simple_tradeable_deposit.py
+++ b/derivatives/models/simple_tradeable_deposit.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class SimpleTradeableDeposit(DerivativeModel):
+    """Placeholder for the SimpleTradeableDeposit pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using SimpleTradeableDeposit model."""
+        raise NotImplementedError("SimpleTradeableDeposit pricing not implemented")

--- a/derivatives/models/synthetic_underlying_forward.py
+++ b/derivatives/models/synthetic_underlying_forward.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class SyntheticUnderlyingForward(DerivativeModel):
+    """Placeholder for the SyntheticUnderlyingForward pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using SyntheticUnderlyingForward model."""
+        raise NotImplementedError("SyntheticUnderlyingForward pricing not implemented")

--- a/derivatives/models/theoretical_dividend_futures.py
+++ b/derivatives/models/theoretical_dividend_futures.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class TheoreticalDividendFutures(DerivativeModel):
+    """Placeholder for the TheoreticalDividendFutures pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using TheoreticalDividendFutures model."""
+        raise NotImplementedError("TheoreticalDividendFutures pricing not implemented")

--- a/derivatives/models/theoretical_dividend_neutral_futures.py
+++ b/derivatives/models/theoretical_dividend_neutral_futures.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class TheoreticalDividendNeutralFutures(DerivativeModel):
+    """Placeholder for the TheoreticalDividendNeutralFutures pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using TheoreticalDividendNeutralFutures model."""
+        raise NotImplementedError("TheoreticalDividendNeutralFutures pricing not implemented")

--- a/derivatives/models/theoretical_simple_dividend_option.py
+++ b/derivatives/models/theoretical_simple_dividend_option.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class TheoreticalSimpleDividendOption(DerivativeModel):
+    """Placeholder for the TheoreticalSimpleDividendOption pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using TheoreticalSimpleDividendOption model."""
+        raise NotImplementedError("TheoreticalSimpleDividendOption pricing not implemented")

--- a/derivatives/models/total_return_swap.py
+++ b/derivatives/models/total_return_swap.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class TotalReturnSwap(DerivativeModel):
+    """Placeholder for the TotalReturnSwap pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using TotalReturnSwap model."""
+        raise NotImplementedError("TotalReturnSwap pricing not implemented")

--- a/derivatives/models/udmc_cliquet_model.py
+++ b/derivatives/models/udmc_cliquet_model.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class UDMCCliquetModel(DerivativeModel):
+    """Placeholder for the UDMCCliquetModel pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using UDMCCliquetModel model."""
+        raise NotImplementedError("UDMCCliquetModel pricing not implemented")

--- a/derivatives/models/underlying_spot.py
+++ b/derivatives/models/underlying_spot.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class UnderlyingSpot(DerivativeModel):
+    """Placeholder for the UnderlyingSpot pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using UnderlyingSpot model."""
+        raise NotImplementedError("UnderlyingSpot pricing not implemented")

--- a/derivatives/models/zero_coupon.py
+++ b/derivatives/models/zero_coupon.py
@@ -1,0 +1,8 @@
+from .base import DerivativeModel
+
+class ZeroCoupon(DerivativeModel):
+    """Placeholder for the ZeroCoupon pricing logic."""
+
+    def price(self, *args, **kwargs):
+        """Compute price using ZeroCoupon model."""
+        raise NotImplementedError("ZeroCoupon pricing not implemented")


### PR DESCRIPTION
## Summary
- add a Python package `derivatives` containing placeholder pricing model classes
- update README with a table of the in/out-of-scope models and notes

## Testing
- `git status --short`