### PR TITLE
Implement simple pricing logic

### DIFF
--- a/derivatives/models/constant_debt_to_equity.py
+++ b/derivatives/models/constant_debt_to_equity.py
@@ -1,8 +1,42 @@
+from __future__ import annotations
+
 from .base import DerivativeModel
 
-class ConstantDebtToEquity(DerivativeModel):
-    """Placeholder for the ConstantDebtToEquity pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using ConstantDebtToEquity model."""
-        raise NotImplementedError("ConstantDebtToEquity pricing not implemented")
+class ConstantDebtToEquity(DerivativeModel):
+    """Simple model for an instrument referencing a constant debt to equity ratio.
+
+    The price is computed as::
+
+        price = equity_price * (1 + debt_to_equity_ratio)
+
+    This represents a linear payoff that increases proportionally with the
+    underlying equity price and the specified debt/equity ratio.
+    """
+
+    def price(self, equity_price: float, debt_to_equity_ratio: float) -> float:
+        """Compute price using a constant debt-to-equity relationship.
+
+        Parameters
+        ----------
+        equity_price:
+            Current price of the underlying equity.
+        debt_to_equity_ratio:
+            Ratio of debt relative to equity.
+
+        Returns
+        -------
+        float
+            Value of the instrument based on the simple formula above.
+        """
+
+        if not isinstance(equity_price, (int, float)):
+            raise TypeError("equity_price must be numeric")
+        if not isinstance(debt_to_equity_ratio, (int, float)):
+            raise TypeError("debt_to_equity_ratio must be numeric")
+        if equity_price < 0:
+            raise ValueError("equity_price cannot be negative")
+        if debt_to_equity_ratio < 0:
+            raise ValueError("debt_to_equity_ratio cannot be negative")
+
+        return equity_price * (1.0 + debt_to_equity_ratio)

--- a/derivatives/models/credit_basket_linear.py
+++ b/derivatives/models/credit_basket_linear.py
@@ -1,8 +1,71 @@
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
 from .base import DerivativeModel
 
-class CreditBasketLinear(DerivativeModel):
-    """Placeholder for the CreditBasketLinear pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using CreditBasketLinear model."""
-        raise NotImplementedError("CreditBasketLinear pricing not implemented")
+class CreditBasketLinear(DerivativeModel):
+    """Linear credit basket model calculating expected default loss.
+
+    The price is calculated as the sum of the expected losses of each name in
+    the basket::
+
+        price = sum(notional_i * p_i * (1 - recovery_i))
+
+    where ``p_i`` is the probability of default derived from market spreads or
+    a hazard rate model and ``recovery_i`` is the fractional recovery rate.
+    """
+
+    def price(
+        self,
+        notionals: Sequence[float],
+        default_probabilities: Sequence[float],
+        recovery_rates: Iterable[float] | None = None,
+    ) -> float:
+        """Compute price using a simple linear credit basket assumption.
+
+        Parameters
+        ----------
+        notionals:
+            Nominal amounts for each credit name in the basket.
+        default_probabilities:
+            Corresponding default probabilities for each credit name.
+        recovery_rates:
+            Fraction of notional recovered on default (defaults to zero for
+            each name if not supplied).
+
+        Returns
+        -------
+        float
+            Present value of the expected credit losses.
+        """
+
+        notionals = list(notionals)
+        probabilities = list(default_probabilities)
+        if recovery_rates is None:
+            recoveries = [0.0] * len(notionals)
+        else:
+            recoveries = list(recovery_rates)
+
+        if not (len(notionals) == len(probabilities) == len(recoveries)):
+            raise ValueError("Input sequences must have the same length")
+
+        total = 0.0
+        for n, p, r in zip(notionals, probabilities, recoveries):
+            if not isinstance(n, (int, float)):
+                raise TypeError("notional values must be numeric")
+            if not isinstance(p, (int, float)):
+                raise TypeError("default probabilities must be numeric")
+            if not isinstance(r, (int, float)):
+                raise TypeError("recovery rates must be numeric")
+            if n < 0:
+                raise ValueError("notional cannot be negative")
+            if not 0.0 <= p <= 1.0:
+                raise ValueError("default probability must be between 0 and 1")
+            if not 0.0 <= r <= 1.0:
+                raise ValueError("recovery rate must be between 0 and 1")
+
+            total += n * p * (1.0 - r)
+
+        return total

--- a/derivatives/models/fund_instrument.py
+++ b/derivatives/models/fund_instrument.py
@@ -1,8 +1,34 @@
+from __future__ import annotations
+
 from .base import DerivativeModel
 
-class FundInstrument(DerivativeModel):
-    """Placeholder for the FundInstrument pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using FundInstrument model."""
-        raise NotImplementedError("FundInstrument pricing not implemented")
+class FundInstrument(DerivativeModel):
+    """Simple fund instrument priced as NAV multiplied by units held."""
+
+    def price(self, nav: float, units: float) -> float:
+        """Return the value of the fund position.
+
+        Parameters
+        ----------
+        nav:
+            Net asset value per unit of the fund.
+        units:
+            Number of units held.
+
+        Returns
+        -------
+        float
+            Value of the position.
+        """
+
+        if not isinstance(nav, (int, float)):
+            raise TypeError("nav must be numeric")
+        if not isinstance(units, (int, float)):
+            raise TypeError("units must be numeric")
+        if nav < 0:
+            raise ValueError("nav cannot be negative")
+        if units < 0:
+            raise ValueError("units cannot be negative")
+
+        return nav * units

--- a/derivatives/models/hazard_rate_model.py
+++ b/derivatives/models/hazard_rate_model.py
@@ -1,8 +1,56 @@
+from __future__ import annotations
+
+import math
+
 from .base import DerivativeModel
 
-class HazardRateModel(DerivativeModel):
-    """Placeholder for the HazardRateModel pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using HazardRateModel model."""
-        raise NotImplementedError("HazardRateModel pricing not implemented")
+class HazardRateModel(DerivativeModel):
+    """Simple hazard rate model for expected default loss valuation."""
+
+    def price(
+        self,
+        notional: float,
+        hazard_rate: float,
+        maturity: float,
+        discount_rate: float = 0.0,
+    ) -> float:
+        """Compute the discounted expected loss using a constant hazard rate.
+
+        The underlying formula is::
+
+            survival = exp(-hazard_rate * maturity)
+            expected_loss = notional * (1 - survival)
+            price = expected_loss * exp(-discount_rate * maturity)
+
+        Parameters
+        ----------
+        notional:
+            Exposure at default.
+        hazard_rate:
+            Constant hazard (default intensity) per annum.
+        maturity:
+            Time horizon in years.
+        discount_rate:
+            Risk-free discount rate used for present valuing the loss.
+
+        Returns
+        -------
+        float
+            Present value of the expected loss.
+        """
+
+        for name, value in {
+            "notional": notional,
+            "hazard_rate": hazard_rate,
+            "maturity": maturity,
+            "discount_rate": discount_rate,
+        }.items():
+            if not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if value < 0:
+                raise ValueError(f"{name} cannot be negative")
+
+        survival = math.exp(-hazard_rate * maturity)
+        expected_loss = notional * (1.0 - survival)
+        return expected_loss * math.exp(-discount_rate * maturity)

--- a/derivatives/models/udmc_cliquet_model.py
+++ b/derivatives/models/udmc_cliquet_model.py
@@ -1,8 +1,54 @@
+from __future__ import annotations
+
+from typing import Iterable
+
 from .base import DerivativeModel
 
-class UDMCCliquetModel(DerivativeModel):
-    """Placeholder for the UDMCCliquetModel pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using UDMCCliquetModel model."""
-        raise NotImplementedError("UDMCCliquetModel pricing not implemented")
+class UDMCCliquetModel(DerivativeModel):
+    """Simplified Cliquet option model using cap and floor on periodic returns."""
+
+    def price(
+        self,
+        returns: Iterable[float],
+        cap: float,
+        floor: float,
+        notional: float = 1.0,
+    ) -> float:
+        """Price a cliquet option with uniform cap and floor per period.
+
+        Parameters
+        ----------
+        returns:
+            Sequence of periodic returns of the underlying.
+        cap:
+            Maximum payoff per period.
+        floor:
+            Minimum payoff per period.
+        notional:
+            Notional amount of the option.
+
+        Returns
+        -------
+        float
+            Sum of capped and floored returns multiplied by the notional.
+        """
+
+        if cap < floor:
+            raise ValueError("cap must be greater than or equal to floor")
+        if not isinstance(notional, (int, float)):
+            raise TypeError("notional must be numeric")
+        if notional < 0:
+            raise ValueError("notional cannot be negative")
+
+        processed_returns = []
+        for r in returns:
+            if not isinstance(r, (int, float)):
+                raise TypeError("returns must contain numeric values")
+            processed_returns.append(r)
+
+        payoff = 0.0
+        for r in processed_returns:
+            payoff += min(max(r, floor), cap)
+
+        return notional * payoff


### PR DESCRIPTION
## Summary
- implement pricing for ConstantDebtToEquity model
- implement linear credit basket pricing
- add hazard rate pricing logic for credit risk
- add simple fund instrument pricing
- implement a basic Cliquet option model

## Testing
- `python -m py_compile $(git ls-files '*.py')`