### PR TITLE
Implement pricing formulas for several models

### DIFF
--- a/derivatives/models/corporate_bond_model.py
+++ b/derivatives/models/corporate_bond_model.py
@@ -1,8 +1,51 @@
+"""Simple corporate bond pricing model."""
+
+from math import exp
+
 from .base import DerivativeModel
 
-class CorporateBondModel(DerivativeModel):
-    """Placeholder for the CorporateBondModel pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using CorporateBondModel model."""
-        raise NotImplementedError("CorporateBondModel pricing not implemented")
+class CorporateBondModel(DerivativeModel):
+    """Price a fixed-coupon corporate bond using continuous discounting.
+
+    Parameters
+    ----------
+    face_value : float
+        Amount paid at maturity.
+    coupon_rate : float
+        Annual coupon rate expressed as a decimal.
+    yield_rate : float
+        Continuously compounded yield to maturity.
+    maturity : float
+        Time to maturity in years.
+    frequency : int, optional
+        Number of coupon payments per year, default is ``1``.
+
+    Notes
+    -----
+    The price is the present value of all coupons and the face value::
+
+        P = \sum_{i=1}^{N} C \* exp(-y t_i) + F \* exp(-y T)
+
+    where ``C`` is the coupon payment, ``y`` the yield and ``t_i`` the cash flow
+    time.  See any standard fixed income text.
+    """
+
+    def price(
+        self,
+        face_value: float,
+        coupon_rate: float,
+        yield_rate: float,
+        maturity: float,
+        frequency: int = 1,
+    ) -> float:
+        """Return the price of the bond."""
+
+        periods = int(maturity * frequency)
+        coupon = face_value * coupon_rate / frequency
+        value = 0.0
+        for i in range(1, periods + 1):
+            t = i / frequency
+            value += coupon * exp(-yield_rate * t)
+        value += face_value * exp(-yield_rate * maturity)
+        return value

--- a/derivatives/models/index_linked_bond_forward.py
+++ b/derivatives/models/index_linked_bond_forward.py
@@ -1,8 +1,38 @@
+"""Model for a simple index linked bond forward."""
+
+from math import exp
+
 from .base import DerivativeModel
 
-class IndexLinkedBondForward(DerivativeModel):
-    """Placeholder for the IndexLinkedBondForward pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using IndexLinkedBondForward model."""
-        raise NotImplementedError("IndexLinkedBondForward pricing not implemented")
+class IndexLinkedBondForward(DerivativeModel):
+    """Price a forward on an inflation index linked bond.
+
+    Parameters
+    ----------
+    notional : float
+        Principal amount of the bond.
+    real_rate : float
+        Continuously compounded real discount rate.
+    maturity : float
+        Time to maturity in years.
+    index_ratio : float
+        Ratio of the current index level to the base index level.
+
+    Notes
+    -----
+    A forward price ``F`` on an index linked bond is commonly approximated by
+    ``F = N * index_ratio * exp(-r * T)``, where ``N`` is the notional, ``r`` is
+    the real rate and ``T`` is the time to maturity.
+    """
+
+    def price(
+        self,
+        notional: float,
+        real_rate: float,
+        maturity: float,
+        index_ratio: float,
+    ) -> float:
+        """Return the forward price."""
+
+        return notional * index_ratio * exp(-real_rate * maturity)

--- a/derivatives/models/price_curve.py
+++ b/derivatives/models/price_curve.py
@@ -1,8 +1,43 @@
+"""Simple price curve model using linear interpolation."""
+
+from bisect import bisect_left
+
 from .base import DerivativeModel
 
-class PriceCurve(DerivativeModel):
-    """Placeholder for the PriceCurve pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using PriceCurve model."""
-        raise NotImplementedError("PriceCurve pricing not implemented")
+class PriceCurve(DerivativeModel):
+    """Linearly interpolated price curve.
+
+    Parameters
+    ----------
+    times : list[float]
+        Ordered time points in years.
+    prices : list[float]
+        Price at each time point.
+
+    Notes
+    -----
+    Prices for intermediate times are obtained via linear interpolation between
+    the two surrounding known points.
+    """
+
+    def __init__(self, times: list[float], prices: list[float]):
+        self.times = times
+        self.prices = prices
+
+    def price(self, time: float) -> float:
+        """Return the interpolated price at ``time``."""
+
+        if not self.times:
+            raise ValueError("Price curve has no data")
+
+        if time <= self.times[0]:
+            return self.prices[0]
+        if time >= self.times[-1]:
+            return self.prices[-1]
+
+        idx = bisect_left(self.times, time)
+        t0, t1 = self.times[idx - 1], self.times[idx]
+        p0, p1 = self.prices[idx - 1], self.prices[idx]
+        weight = (time - t0) / (t1 - t0)
+        return p0 + weight * (p1 - p0)

--- a/derivatives/models/simple_tradeable_deposit.py
+++ b/derivatives/models/simple_tradeable_deposit.py
@@ -1,8 +1,31 @@
+"""Model for a tradeable fixed-rate deposit."""
+
 from .base import DerivativeModel
 
-class SimpleTradeableDeposit(DerivativeModel):
-    """Placeholder for the SimpleTradeableDeposit pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using SimpleTradeableDeposit model."""
-        raise NotImplementedError("SimpleTradeableDeposit pricing not implemented")
+class SimpleTradeableDeposit(DerivativeModel):
+    """Accrued value of a simple deposit.
+
+    Parameters
+    ----------
+    principal : float
+        Initial amount deposited.
+    rate : float
+        Annual simple interest rate as a decimal.
+    maturity : float
+        Time to maturity in years.
+
+    Notes
+    -----
+    The value ``V`` of a deposit accruing simple interest is given by::
+
+        V = P * (1 + r * T)
+
+    where ``P`` is the principal, ``r`` is the interest rate and ``T`` is the
+    time in years.
+    """
+
+    def price(self, principal: float, rate: float, maturity: float) -> float:
+        """Return the maturity value of the deposit."""
+
+        return principal * (1 + rate * maturity)

--- a/derivatives/models/zero_coupon.py
+++ b/derivatives/models/zero_coupon.py
@@ -1,8 +1,33 @@
+"""Zero-coupon bond pricing model."""
+
+from math import exp
+
 from .base import DerivativeModel
 
-class ZeroCoupon(DerivativeModel):
-    """Placeholder for the ZeroCoupon pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using ZeroCoupon model."""
-        raise NotImplementedError("ZeroCoupon pricing not implemented")
+class ZeroCoupon(DerivativeModel):
+    """Model for pricing a zero-coupon bond.
+
+    Parameters
+    ----------
+    face_value : float
+        Amount paid at maturity.
+    discount_rate : float
+        Continuously compounded annual interest rate.
+    maturity : float
+        Time to maturity in years.
+
+    Notes
+    -----
+    The price ``P`` of a zero-coupon bond is given by::
+
+        P = F * exp(-r * T)
+
+    where ``F`` is the face value, ``r`` is the discount rate and ``T`` is the
+    time to maturity.  See Hull, *Options, Futures, and Other Derivatives*.
+    """
+
+    def price(self, face_value: float, discount_rate: float, maturity: float) -> float:
+        """Return the present value of the bond."""
+
+        return face_value * exp(-discount_rate * maturity)


### PR DESCRIPTION
## Summary
- implement zero coupon present value formula
- add linear interpolation to PriceCurve
- compute index linked bond forward price
- price fixed-coupon corporate bonds
- value simple tradeable deposits

## Testing
- `python -m py_compile derivatives/models/zero_coupon.py derivatives/models/price_curve.py derivatives/models/index_linked_bond_forward.py derivatives/models/corporate_bond_model.py derivatives/models/simple_tradeable_deposit.py`
- `python -m pytest -q` *(fails: No module named pytest)*