### PR TITLE
Implement option pricing models

### DIFF
--- a/derivatives/models/asian_arithmetic_fix_mm.py
+++ b/derivatives/models/asian_arithmetic_fix_mm.py
@@ -1,8 +1,71 @@
+"""Arithmetic Asian option model with fixed monitoring dates."""
+
+from math import exp
+
+import numpy as np
+
 from .base import DerivativeModel
 
 class AsianArithmeticFixMM(DerivativeModel):
-    """Placeholder for the AsianArithmeticFixMM pricing logic."""
+    """Monte Carlo pricer for arithmetic-average Asian options.
 
-    def price(self, *args, **kwargs):
-        """Compute price using AsianArithmeticFixMM model."""
-        raise NotImplementedError("AsianArithmeticFixMM pricing not implemented")
+    Parameters mirror the standard Black--Scholes setting.  Monitoring of the
+    underlying price is assumed to take place at equally spaced intervals.
+    """
+
+    def price(
+        self,
+        spot: float,
+        strike: float,
+        rate: float,
+        vol: float,
+        maturity: float,
+        num_obs: int,
+        is_call: bool = True,
+        n_paths: int = 10_000,
+    ) -> float:
+        """Return the value of the Asian option.
+
+        Parameters
+        ----------
+        spot:
+            Current price of the underlying asset.
+        strike:
+            Option strike level.
+        rate:
+            Continuously compounded risk free rate.
+        vol:
+            Annualised volatility of the underlying.
+        maturity:
+            Time to maturity in years.
+        num_obs:
+            Number of equally spaced observation dates.
+        is_call:
+            ``True`` for a call option, ``False`` for a put.
+        n_paths:
+            Number of Monte Carlo paths to simulate.
+
+        Returns
+        -------
+        float
+            Present value of the Asian option.
+        """
+
+        dt = maturity / num_obs
+        drift = (rate - 0.5 * vol ** 2) * dt
+        diffusion = vol * np.sqrt(dt)
+
+        payoffs = np.zeros(n_paths)
+        for p in range(n_paths):
+            price_path = spot
+            running_sum = 0.0
+            for _ in range(num_obs):
+                price_path *= np.exp(drift + diffusion * np.random.normal())
+                running_sum += price_path
+            average_price = running_sum / num_obs
+            if is_call:
+                payoffs[p] = max(average_price - strike, 0.0)
+            else:
+                payoffs[p] = max(strike - average_price, 0.0)
+
+        return float(exp(-rate * maturity) * payoffs.mean())

--- a/derivatives/models/barrier_continuous_analytic.py
+++ b/derivatives/models/barrier_continuous_analytic.py
@@ -1,8 +1,80 @@
+"""Continuously monitored barrier option priced via Monte Carlo."""
+
+from math import exp
+
+import numpy as np
+
 from .base import DerivativeModel
 
 class BarrierContinuousAnalytic(DerivativeModel):
-    """Placeholder for the BarrierContinuousAnalytic pricing logic."""
+    """Approximate pricer for continuously monitored barrier options."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using BarrierContinuousAnalytic model."""
-        raise NotImplementedError("BarrierContinuousAnalytic pricing not implemented")
+    def price(
+        self,
+        spot: float,
+        strike: float,
+        barrier: float,
+        rate: float,
+        vol: float,
+        maturity: float,
+        is_call: bool = True,
+        barrier_type: str = "down-and-out",
+        n_steps: int = 200,
+        n_paths: int = 10_000,
+    ) -> float:
+        """Return the value of the barrier option using simulation.
+
+        Parameters
+        ----------
+        spot:
+            Current spot price.
+        strike:
+            Option strike level.
+        barrier:
+            Barrier level.
+        rate:
+            Risk free rate.
+        vol:
+            Volatility of the underlying.
+        maturity:
+            Time to maturity in years.
+        is_call:
+            ``True`` for a call option, ``False`` for a put.
+        barrier_type:
+            Either ``"down-and-out"`` or ``"up-and-out"``.
+        n_steps:
+            Number of monitoring steps used to approximate the continuous
+            barrier.
+        n_paths:
+            Number of Monte Carlo paths.
+
+        Returns
+        -------
+        float
+            Present value of the barrier option.
+        """
+
+        dt = maturity / n_steps
+        drift = (rate - 0.5 * vol ** 2) * dt
+        diffusion = vol * np.sqrt(dt)
+
+        payoffs = np.zeros(n_paths)
+        for p in range(n_paths):
+            price_path = spot
+            knocked_out = False
+            for _ in range(n_steps):
+                price_path *= np.exp(drift + diffusion * np.random.normal())
+                if barrier_type == "down-and-out" and price_path <= barrier:
+                    knocked_out = True
+                    break
+                if barrier_type == "up-and-out" and price_path >= barrier:
+                    knocked_out = True
+                    break
+
+            if not knocked_out:
+                if is_call:
+                    payoffs[p] = max(price_path - strike, 0.0)
+                else:
+                    payoffs[p] = max(strike - price_path, 0.0)
+
+        return float(exp(-rate * maturity) * payoffs.mean())

--- a/derivatives/models/commodity_asian_option.py
+++ b/derivatives/models/commodity_asian_option.py
@@ -1,8 +1,70 @@
+"""Arithmetic Asian option pricer for commodity underlyings."""
+
+from math import exp
+
+import numpy as np
+
 from .base import DerivativeModel
 
 class CommodityAsianOption(DerivativeModel):
-    """Placeholder for the CommodityAsianOption pricing logic."""
+    """Monte Carlo pricer for arithmetic-average Asian options on commodities."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using CommodityAsianOption model."""
-        raise NotImplementedError("CommodityAsianOption pricing not implemented")
+    def price(
+        self,
+        spot: float,
+        strike: float,
+        rate: float,
+        vol: float,
+        maturity: float,
+        num_obs: int,
+        convenience_yield: float = 0.0,
+        is_call: bool = True,
+        n_paths: int = 10_000,
+    ) -> float:
+        """Return the option value.
+
+        Parameters
+        ----------
+        spot:
+            Current spot price of the commodity.
+        strike:
+            Option strike level.
+        rate:
+            Continuously compounded risk free rate.
+        vol:
+            Annualised volatility of the underlying.
+        maturity:
+            Time to maturity in years.
+        num_obs:
+            Number of equally spaced observation dates.
+        convenience_yield:
+            Convenience yield of the commodity.
+        is_call:
+            ``True`` for a call option, ``False`` for a put.
+        n_paths:
+            Number of Monte Carlo paths.
+
+        Returns
+        -------
+        float
+            Present value of the Asian option.
+        """
+
+        dt = maturity / num_obs
+        drift = (rate - convenience_yield - 0.5 * vol ** 2) * dt
+        diffusion = vol * np.sqrt(dt)
+
+        payoffs = np.zeros(n_paths)
+        for p in range(n_paths):
+            price_path = spot
+            running_sum = 0.0
+            for _ in range(num_obs):
+                price_path *= np.exp(drift + diffusion * np.random.normal())
+                running_sum += price_path
+            avg_price = running_sum / num_obs
+            if is_call:
+                payoffs[p] = max(avg_price - strike, 0.0)
+            else:
+                payoffs[p] = max(strike - avg_price, 0.0)
+
+        return float(exp(-rate * maturity) * payoffs.mean())

--- a/derivatives/models/discretised_barrier.py
+++ b/derivatives/models/discretised_barrier.py
@@ -1,8 +1,79 @@
+"""Discretely monitored barrier option priced via Monte Carlo."""
+
+from math import exp
+
+import numpy as np
+
 from .base import DerivativeModel
 
 class DiscretisedBarrier(DerivativeModel):
-    """Placeholder for the DiscretisedBarrier pricing logic."""
+    """Monte Carlo pricer for discretely monitored barrier options."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using DiscretisedBarrier model."""
-        raise NotImplementedError("DiscretisedBarrier pricing not implemented")
+    def price(
+        self,
+        spot: float,
+        strike: float,
+        barrier: float,
+        rate: float,
+        vol: float,
+        maturity: float,
+        monitoring_times: int,
+        is_call: bool = True,
+        barrier_type: str = "down-and-out",
+        n_paths: int = 10_000,
+    ) -> float:
+        """Return the value of the discretely monitored barrier option.
+
+        Parameters
+        ----------
+        spot:
+            Current spot price.
+        strike:
+            Strike of the option.
+        barrier:
+            Barrier level.
+        rate:
+            Risk free rate.
+        vol:
+            Volatility of the underlying.
+        maturity:
+            Time to maturity in years.
+        monitoring_times:
+            Number of equally spaced barrier observation dates.
+        is_call:
+            ``True`` for a call, ``False`` for a put.
+        barrier_type:
+            Either ``"down-and-out"`` or ``"up-and-out"``.
+        n_paths:
+            Number of Monte Carlo paths.
+
+        Returns
+        -------
+        float
+            Present value of the option.
+        """
+
+        dt = maturity / monitoring_times
+        drift = (rate - 0.5 * vol ** 2) * dt
+        diffusion = vol * np.sqrt(dt)
+
+        payoffs = np.zeros(n_paths)
+        for p in range(n_paths):
+            price_path = spot
+            knocked_out = False
+            for _ in range(monitoring_times):
+                price_path *= np.exp(drift + diffusion * np.random.normal())
+                if barrier_type == "down-and-out" and price_path <= barrier:
+                    knocked_out = True
+                    break
+                if barrier_type == "up-and-out" and price_path >= barrier:
+                    knocked_out = True
+                    break
+
+            if not knocked_out:
+                if is_call:
+                    payoffs[p] = max(price_path - strike, 0.0)
+                else:
+                    payoffs[p] = max(strike - price_path, 0.0)
+
+        return float(exp(-rate * maturity) * payoffs.mean())

--- a/derivatives/models/finite_difference.py
+++ b/derivatives/models/finite_difference.py
@@ -1,8 +1,86 @@
+"""Simple finite-difference solver for the Black--Scholes PDE."""
+
+from math import exp
+
+import numpy as np
+
 from .base import DerivativeModel
 
 class FiniteDifference(DerivativeModel):
-    """Placeholder for the FiniteDifference pricing logic."""
+    """Explicit finite-difference pricer for European options."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using FiniteDifference model."""
-        raise NotImplementedError("FiniteDifference pricing not implemented")
+    def price(
+        self,
+        spot: float,
+        strike: float,
+        rate: float,
+        vol: float,
+        maturity: float,
+        is_call: bool = True,
+        s_max: float | None = None,
+        n_time: int = 200,
+        n_space: int = 200,
+    ) -> float:
+        """Solve the Black--Scholes PDE on a finite grid.
+
+        Parameters
+        ----------
+        spot:
+            Spot price of the underlying.
+        strike:
+            Option strike level.
+        rate:
+            Risk free interest rate.
+        vol:
+            Volatility of the underlying asset.
+        maturity:
+            Time to maturity in years.
+        is_call:
+            ``True`` for a call, ``False`` for a put.
+        s_max:
+            Maximum spot value considered in the grid. Defaults to ``2 * strike``.
+        n_time:
+            Number of time steps in the grid.
+        n_space:
+            Number of price steps in the grid.
+
+        Returns
+        -------
+        float
+            Approximation of the option price.
+        """
+
+        s_max = 2 * strike if s_max is None else s_max
+
+        dt = maturity / n_time
+        ds = s_max / n_space
+
+        grid = np.zeros(n_space + 1)
+        s_values = np.linspace(0, s_max, n_space + 1)
+
+        if is_call:
+            grid = np.maximum(s_values - strike, 0)
+        else:
+            grid = np.maximum(strike - s_values, 0)
+
+        for _ in range(n_time):
+            new_grid = grid.copy()
+            for i in range(1, n_space):
+                s = i * ds
+                delta = (grid[i + 1] - grid[i - 1]) / (2 * ds)
+                gamma = (grid[i + 1] - 2 * grid[i] + grid[i - 1]) / (ds**2)
+                theta = (
+                    -0.5 * vol**2 * s**2 * gamma
+                    - rate * s * delta
+                    + rate * grid[i]
+                )
+                new_grid[i] = grid[i] - dt * theta
+
+            new_grid[0] = 0 if is_call else strike * exp(-rate * (_ * dt))
+            new_grid[-1] = s_max - strike * exp(-rate * (_ * dt)) if is_call else 0
+            grid = new_grid
+
+        i = int(spot / ds)
+        weight = (spot - i * ds) / ds
+        price = grid[i] * (1 - weight) + grid[i + 1] * weight
+        return float(price)

--- a/derivatives/models/qedi_variable_strike_warrant.py
+++ b/derivatives/models/qedi_variable_strike_warrant.py
@@ -1,8 +1,55 @@
+"""Model for variable strike warrants using Black--Scholes."""
+
+from math import exp, log, sqrt
+
+from scipy.stats import norm
+
 from .base import DerivativeModel
 
 class QEDIVariableStrikeWarrant(DerivativeModel):
-    """Placeholder for the QEDIVariableStrikeWarrant pricing logic."""
+    """European warrant with strike proportional to the underlying spot."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using QEDIVariableStrikeWarrant model."""
-        raise NotImplementedError("QEDIVariableStrikeWarrant pricing not implemented")
+    def price(
+        self,
+        spot: float,
+        strike_ratio: float,
+        rate: float,
+        vol: float,
+        maturity: float,
+        is_call: bool = True,
+    ) -> float:
+        """Return the theoretical value of the variable strike warrant.
+
+        Parameters
+        ----------
+        spot:
+            Current underlying price.
+        strike_ratio:
+            Ratio applied to the spot price to determine the strike at expiry.
+        rate:
+            Risk free rate.
+        vol:
+            Volatility of the underlying asset.
+        maturity:
+            Time to maturity in years.
+        is_call:
+            ``True`` for a call warrant, ``False`` for a put.
+
+        Returns
+        -------
+        float
+            The Black--Scholes value of the warrant.
+        """
+
+        strike = strike_ratio * spot
+        sqrt_t = sqrt(maturity)
+        d1 = (log(spot / strike) + (rate + 0.5 * vol ** 2) * maturity) / (vol * sqrt_t)
+        d2 = d1 - vol * sqrt_t
+
+        df = exp(-rate * maturity)
+        if is_call:
+            price = spot * norm.cdf(d1) - strike * df * norm.cdf(d2)
+        else:
+            price = strike * df * norm.cdf(-d2) - spot * norm.cdf(-d1)
+
+        return float(price)

--- a/derivatives/models/theoretical_simple_dividend_option.py
+++ b/derivatives/models/theoretical_simple_dividend_option.py
@@ -1,8 +1,62 @@
+"""Simple model for options on a single dividend payment."""
+
+from math import exp, log, sqrt
+
+from scipy.stats import norm
+
 from .base import DerivativeModel
 
 class TheoreticalSimpleDividendOption(DerivativeModel):
-    """Placeholder for the TheoreticalSimpleDividendOption pricing logic."""
+    """Black--Scholes style option on an anticipated dividend payment."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using TheoreticalSimpleDividendOption model."""
-        raise NotImplementedError("TheoreticalSimpleDividendOption pricing not implemented")
+    def price(
+        self,
+        expected_dividend: float,
+        strike: float,
+        rate: float,
+        vol: float,
+        maturity: float,
+        is_call: bool = True,
+    ) -> float:
+        """Return the present value of the dividend option.
+
+        Parameters
+        ----------
+        expected_dividend:
+            Expected amount of the dividend at maturity.
+        strike:
+            Option strike level.
+        rate:
+            Continuously compounded risk free rate.
+        vol:
+            Volatility of the dividend forecast.
+        maturity:
+            Time to maturity in years.
+        is_call:
+            ``True`` for a call, ``False`` for a put.
+
+        Returns
+        -------
+        float
+            Present value of the option.
+        """
+
+        if vol <= 0 or maturity <= 0:
+            intrinsic = max(expected_dividend - strike, 0.0)
+            if not is_call:
+                intrinsic = max(strike - expected_dividend, 0.0)
+            return float(exp(-rate * maturity) * intrinsic)
+
+        sqrt_t = sqrt(maturity)
+        d1 = (log(expected_dividend / strike) + 0.5 * vol ** 2 * maturity) / (
+            vol * sqrt_t
+        )
+        d2 = d1 - vol * sqrt_t
+
+        df = exp(-rate * maturity)
+        if is_call:
+            price = expected_dividend * norm.cdf(d1) - strike * norm.cdf(d2)
+        else:
+            price = strike * norm.cdf(-d2) - expected_dividend * norm.cdf(-d1)
+
+        return float(df * price)


### PR DESCRIPTION
## Summary
- implement Monte Carlo pricing for Asian options
- implement barrier option pricers
- add finite difference solver for Black-Scholes PDE
- price theoretical dividend and variable strike warrant options

## Testing
- `python -m py_compile $(git ls-files '*.py')`