### PR TITLE
Add forward and swap pricing algorithms

### DIFF
--- a/derivatives/models/fully_funded_trs.py
+++ b/derivatives/models/fully_funded_trs.py
@@ -1,8 +1,36 @@
+"""Pricing model for a fully funded total return swap."""
+
+from math import exp
+
 from .base import DerivativeModel
 
-class FullyFundedTRS(DerivativeModel):
-    """Placeholder for the FullyFundedTRS pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using FullyFundedTRS model."""
-        raise NotImplementedError("FullyFundedTRS pricing not implemented")
+class FullyFundedTRS(DerivativeModel):
+    """Value a fully funded total return swap (compound model).
+
+    Assumptions
+    ----------
+    * Funding and discounting use the same constant rate.
+    * Dividends accrue continuously at a known yield.
+
+    Payoff
+    ------
+    The holder receives ``S_T`` and pays back the funded amount
+    ``S_0 * exp(funding_rate * T)``.
+    """
+
+    def price(
+        self,
+        spot_price: float,
+        expected_terminal_price: float,
+        funding_rate: float,
+        dividend_yield: float,
+        time_to_maturity: float,
+        notional: float = 1.0,
+    ) -> float:
+        """Return the present value of the fully funded TRS."""
+
+        funded_amount = spot_price * exp(funding_rate * time_to_maturity)
+        expected_asset = expected_terminal_price * exp(-dividend_yield * time_to_maturity)
+        payoff = expected_asset - funded_amount
+        return notional * payoff * exp(-funding_rate * time_to_maturity)

--- a/derivatives/models/synthetic_underlying_forward.py
+++ b/derivatives/models/synthetic_underlying_forward.py
@@ -1,8 +1,47 @@
+"""Pricing model for a synthetic underlying forward."""
+
+from math import exp
+
 from .base import DerivativeModel
 
-class SyntheticUnderlyingForward(DerivativeModel):
-    """Placeholder for the SyntheticUnderlyingForward pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using SyntheticUnderlyingForward model."""
-        raise NotImplementedError("SyntheticUnderlyingForward pricing not implemented")
+class SyntheticUnderlyingForward(DerivativeModel):
+    """Compute the fair forward price using the cost-of-carry approach.
+
+    Assumptions
+    ----------
+    * Constant risk-free rate and continuous dividend yield.
+    * No transaction costs.
+
+    Payoff
+    ------
+    At maturity :math:`T` the forward contract delivers
+    ``notional * (S_T - F)`` where ``F`` is the forward price computed below.
+    """
+
+    def price(
+        self,
+        spot_price: float,
+        risk_free_rate: float,
+        dividend_yield: float,
+        time_to_maturity: float,
+        notional: float = 1.0,
+    ) -> float:
+        """Return the synthetic forward price.
+
+        Parameters
+        ----------
+        spot_price:
+            Current underlying spot price ``S_0``.
+        risk_free_rate:
+            Continuously compounded risk-free rate ``r``.
+        dividend_yield:
+            Continuous dividend yield ``q`` of the underlying.
+        time_to_maturity:
+            Time to delivery ``T`` in years.
+        notional:
+            Number of units of the underlying.
+        """
+
+        forward_price = spot_price * exp((risk_free_rate - dividend_yield) * time_to_maturity)
+        return notional * forward_price

--- a/derivatives/models/theoretical_dividend_futures.py
+++ b/derivatives/models/theoretical_dividend_futures.py
@@ -1,8 +1,47 @@
+"""Pricing model for theoretical dividend futures."""
+
+from math import exp
+from typing import Iterable, Tuple
+
 from .base import DerivativeModel
 
-class TheoreticalDividendFutures(DerivativeModel):
-    """Placeholder for the TheoreticalDividendFutures pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using TheoreticalDividendFutures model."""
-        raise NotImplementedError("TheoreticalDividendFutures pricing not implemented")
+class TheoreticalDividendFutures(DerivativeModel):
+    """Price a future on the stream of dividends of an underlying asset.
+
+    Assumptions
+    ----------
+    * Constant risk-free rate.
+    * Dividends are paid discretely at known future times.
+
+    Payoff
+    ------
+    The contract pays the sum of dividends over ``[0, T]`` at maturity ``T``.
+    """
+
+    def price(
+        self,
+        dividends: Iterable[Tuple[float, float]],
+        risk_free_rate: float,
+        time_to_maturity: float,
+        notional: float = 1.0,
+    ) -> float:
+        """Return the present value of the dividend future.
+
+        Parameters
+        ----------
+        dividends:
+            Iterable of ``(t, amount)`` pairs representing dividend payments.
+        risk_free_rate:
+            Continuously compounded risk-free rate ``r``.
+        time_to_maturity:
+            Contract maturity ``T`` in years. Payments beyond ``T`` are ignored.
+        notional:
+            Scaling factor for the dividend stream.
+        """
+
+        pv = 0.0
+        for t, amount in dividends:
+            if t <= time_to_maturity:
+                pv += amount * exp(-risk_free_rate * t)
+        return notional * pv

--- a/derivatives/models/theoretical_dividend_neutral_futures.py
+++ b/derivatives/models/theoretical_dividend_neutral_futures.py
@@ -1,8 +1,32 @@
+"""Pricing model for dividend-neutral futures."""
+
+from math import exp
+
 from .base import DerivativeModel
 
-class TheoreticalDividendNeutralFutures(DerivativeModel):
-    """Placeholder for the TheoreticalDividendNeutralFutures pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using TheoreticalDividendNeutralFutures model."""
-        raise NotImplementedError("TheoreticalDividendNeutralFutures pricing not implemented")
+class TheoreticalDividendNeutralFutures(DerivativeModel):
+    """Compute the forward price ignoring dividend effects.
+
+    Assumptions
+    ----------
+    * Constant risk-free rate and dividend yield.
+    * No-arbitrage market.
+
+    Payoff
+    ------
+    At maturity the contract pays ``notional * (S_T - F)`` with
+    ``F = S_0 * exp(r * T)``.
+    """
+
+    def price(
+        self,
+        spot_price: float,
+        risk_free_rate: float,
+        time_to_maturity: float,
+        notional: float = 1.0,
+    ) -> float:
+        """Return the forward price ignoring dividends."""
+
+        forward_price = spot_price * exp(risk_free_rate * time_to_maturity)
+        return notional * forward_price

--- a/derivatives/models/total_return_swap.py
+++ b/derivatives/models/total_return_swap.py
@@ -1,8 +1,36 @@
+"""Pricing model for a simple total return swap."""
+
+from math import exp
+
 from .base import DerivativeModel
 
-class TotalReturnSwap(DerivativeModel):
-    """Placeholder for the TotalReturnSwap pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using TotalReturnSwap model."""
-        raise NotImplementedError("TotalReturnSwap pricing not implemented")
+class TotalReturnSwap(DerivativeModel):
+    """Value a total return swap using a forward estimate of the underlying.
+
+    Assumptions
+    ----------
+    * Constant funding rate and dividend yield.
+    * The expected terminal price is provided and discounted at the funding
+      rate.
+
+    Payoff
+    ------
+    At maturity ``T`` the receiver of total return receives
+    ``notional * (S_T - F_0)`` where ``F_0`` is the initial forward price.
+    """
+
+    def price(
+        self,
+        spot_price: float,
+        expected_terminal_price: float,
+        funding_rate: float,
+        dividend_yield: float,
+        time_to_maturity: float,
+        notional: float = 1.0,
+    ) -> float:
+        """Return the present value of the total return swap."""
+
+        initial_forward = spot_price * exp((funding_rate - dividend_yield) * time_to_maturity)
+        payoff = expected_terminal_price - initial_forward
+        return notional * payoff * exp(-funding_rate * time_to_maturity)

--- a/derivatives/models/underlying_spot.py
+++ b/derivatives/models/underlying_spot.py
@@ -1,8 +1,16 @@
+"""Model representing the underlying spot price."""
+
 from .base import DerivativeModel
 
-class UnderlyingSpot(DerivativeModel):
-    """Placeholder for the UnderlyingSpot pricing logic."""
 
-    def price(self, *args, **kwargs):
-        """Compute price using UnderlyingSpot model."""
-        raise NotImplementedError("UnderlyingSpot pricing not implemented")
+class UnderlyingSpot(DerivativeModel):
+    """Return the spot price of the underlying asset.
+
+    The model assumes the current spot price is observable and no additional
+    adjustments are required.
+    """
+
+    def price(self, spot_price: float, notional: float = 1.0) -> float:
+        """Return ``notional * spot_price``."""
+
+        return notional * spot_price


### PR DESCRIPTION
## Summary
- implement pricing logic for several forward- and swap-based models
- document assumptions and payoff calculations in each class

## Testing
- `python -m py_compile $(git ls-files '*.py')`
