### PR TITLE
Rename HazardRateModel to StaticHazardRateModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The pricing logic still needs to be implemented for each model.
 | Zero Coupon                                    | In        | Only need to test Cross currency swaps with long dated tenors        |
 | Price Curve                                    | In        | Commodity                                                            |
 | Commodity Asian Option                         | In        |                                                                     |
-| Hazard Rate Model                              | In        | FX future/forward, Equity future/forward                             |
+| Static Hazard Rate Model                       | In        | FX future/forward, Equity future/forward                             |
 | Synthetic Underlying Forward                   | In        |                                                                     |
 | Theoretical dividend futures                   | In        |                                                                     |
 | Underlying Spot                                | In        |                                                                     |
@@ -41,3 +41,11 @@ Each model lives under `derivatives/models/` and exposes a `price()` method. The
 models are grouped into subpackages (e.g. `options`, `bonds`, `futures`) to make
 the repository easier to navigate. The current implementation simply raises
 `NotImplementedError` as a placeholder for the actual pricing logic.
+
+## Hazard Rate Models
+
+The ``StaticHazardRateModel`` assumes a single constant default intensity over
+the life of the instrument. In more advanced implementations the hazard rate may
+change over time (a *stepwise* or piecewise-constant approach) or even follow a
+stochastic process. Those models are not included here but are mentioned for
+context.

--- a/derivatives/models/__init__.py
+++ b/derivatives/models/__init__.py
@@ -11,7 +11,7 @@ from .misc.underlying_spot import UnderlyingSpot
 
 # Credit models
 from .credit.credit_basket_linear import CreditBasketLinear
-from .credit.hazard_rate_model import HazardRateModel
+from .credit.static_hazard_rate_model import StaticHazardRateModel
 
 # Bond models
 from .bonds.zero_coupon import ZeroCoupon

--- a/derivatives/models/credit/static_hazard_rate_model.py
+++ b/derivatives/models/credit/static_hazard_rate_model.py
@@ -5,8 +5,14 @@ import math
 from ..base import DerivativeModel
 
 
-class HazardRateModel(DerivativeModel):
-    """Simple hazard rate model for expected default loss valuation."""
+class StaticHazardRateModel(DerivativeModel):
+    """Static hazard rate model for expected default loss valuation.
+
+    This implementation assumes a **constant** default intensity over the
+    life of the exposure. More sophisticated alternatives include
+    stepwise models (where the hazard rate changes at preset intervals) and
+    stochastic models where the intensity follows a random process.
+    """
 
     def price(
         self,

--- a/tests/test_models_price.py
+++ b/tests/test_models_price.py
@@ -9,7 +9,7 @@ MODEL_CLASSES = [
     models.ZeroCoupon,
     models.PriceCurve,
     models.CommodityAsianOption,
-    models.HazardRateModel,
+    models.StaticHazardRateModel,
     models.SyntheticUnderlyingForward,
     models.TheoreticalDividendFutures,
     models.UnderlyingSpot,


### PR DESCRIPTION
## Summary
- rename `HazardRateModel` to `StaticHazardRateModel`
- update references to the renamed model
- document the difference between static, stepwise, and stochastic hazard rate models

## Testing
- `pytest -q` *(fails: command not found)*